### PR TITLE
Fix single variable warning

### DIFF
--- a/R/load_or_download_variables.R
+++ b/R/load_or_download_variables.R
@@ -244,7 +244,7 @@ load_or_download_variables <- function(specification,
   # This must come after saving
   if (constrain.to.minimum.sample) {
     if(!quiet){
-      if(length(availability$n > 1)){
+      if(length(availability$n) > 1){
         if (max(stats::dist(availability$n, method = "maximum") / max(availability$n)) > 0.2) {
           warning("Unbalanced panel, will lose more than 20\\% of data when making balanced")
         }

--- a/R/load_or_download_variables.R
+++ b/R/load_or_download_variables.R
@@ -244,8 +244,10 @@ load_or_download_variables <- function(specification,
   # This must come after saving
   if (constrain.to.minimum.sample) {
     if(!quiet){
-      if (max(stats::dist(availability$n, method = "maximum") / max(availability$n)) > 0.2) {
-        warning("Unbalanced panel, will lose more than 20\\% of data when making balanced")
+      if(length(availability$n > 1)){
+        if (max(stats::dist(availability$n, method = "maximum") / max(availability$n)) > 0.2) {
+          warning("Unbalanced panel, will lose more than 20\\% of data when making balanced")
+        }
       }
     }
     min_date <- max(availability$min_date) # highest minimum date

--- a/tests/testthat/test-3-very-small-example.R
+++ b/tests/testthat/test-3-very-small-example.R
@@ -73,7 +73,7 @@ test_that("Check that single variable model works", {
                             HICP_Gas = rnorm(mean = 200, n = length(time)),
                             FinConsExpHH  = 0.5 + 0.2*FinConsExpGov + 0.3 * HICP_Gas + rnorm(length(time),mean = 0, sd = 0.2))
 
-  # now modify this to simluate the effect of providing external exogenous data but
+  # now modify this to simulate the effect of providing external exogenous data but
   # where we do not provide any values for the values that would otherwise be nowcasted
   # so first we get the exogenous values based of a base case
   # then we set one value in the historical data to NA

--- a/tests/testthat/test-3-very-small-example.R
+++ b/tests/testthat/test-3-very-small-example.R
@@ -50,3 +50,50 @@ test_that("no errors when running very simple model", {
   )
 
 })
+
+
+
+test_that("Check that single variable model works", {
+
+  specification <- dplyr::tibble(
+    type = c(
+      "n"
+    ),
+    dependent = c(
+      "FinConsExpHH"
+    ),
+    independent = c(
+      ""
+    )
+  )
+
+  set.seed(123)
+  testdata <- dplyr::tibble(time = seq.Date(from = as.Date("2005-01-01"), to = as.Date("2023-10-01"), by = "quarter"),
+                            FinConsExpGov = rnorm(mean = 100, n = length(time)),
+                            HICP_Gas = rnorm(mean = 200, n = length(time)),
+                            FinConsExpHH  = 0.5 + 0.2*FinConsExpGov + 0.3 * HICP_Gas + rnorm(length(time),mean = 0, sd = 0.2))
+
+  # now modify this to simluate the effect of providing external exogenous data but
+  # where we do not provide any values for the values that would otherwise be nowcasted
+  # so first we get the exogenous values based of a base case
+  # then we set one value in the historical data to NA
+  testdata %>%
+    dplyr::mutate(FinConsExpHH = dplyr::case_when(time == as.Date("2023-10-01") ~ NA,
+                                                  TRUE ~ FinConsExpHH)) %>%
+    dplyr::mutate(HICP_Gas = dplyr::case_when(time == as.Date("2023-10-01") ~ NA,
+                                              TRUE ~ HICP_Gas)) %>%
+    tidyr::pivot_longer(-time, names_to = "na_item", values_to = "values") -> testdata_modified_long
+
+  # before the fix on 25.07.2025 caused an error
+  expect_output(
+    run_model(specification = specification,
+              dictionary = dict,
+              inputdata_directory = testdata_modified_long,
+              primary_source = "local",
+              present = FALSE,
+              quiet = FALSE,
+              plot = FALSE,
+              constrain.to.minimum.sample = TRUE),
+    regexp = "Variable provided as 'inputdata_directory' seems to be a data.frame type. Used as data source"
+  )
+})


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `load_or_download_variables` function and adds a new test case to improve test coverage for single-variable models. Below are the most important changes:

### Enhancements to `load_or_download_variables` function:
- Added a condition to check if `availability$n` has more than one element before calculating the maximum distance ratio. This prevents potential errors when the length of `availability$n` is insufficient for the calculation. (`R/load_or_download_variables.R`, [R/load_or_download_variables.RR247-R252](diffhunk://#diff-2d6d636c977b1c26b3bb90ae8c4a8e19e2b391de13a8549079a1959ad5fd872cR247-R252))

### Test coverage improvements:
- Added a new test case, `test_that("Check that single variable model works")`, to validate the behavior of single-variable models. This includes generating test data, simulating missing values, and ensuring that the `run_model` function handles these scenarios without errors. (`tests/testthat/test-3-very-small-example.R`, [tests/testthat/test-3-very-small-example.RR53-R99](diffhunk://#diff-408fa9a30798fa454dd52496f2e0cdb1c88072562ca2853b0aec7073cc7d4d97R53-R99))